### PR TITLE
Fix syntax error on older versions of samdb

### DIFF
--- a/guam/router.py
+++ b/guam/router.py
@@ -29,7 +29,9 @@ def get_smb():
     try:
         yield samdb
     finally:
-        samdb.disconnect()
+        # TODO: The version of samdb currently running in production does not have disconnect()
+        # samdb.disconnect()
+        samdb = None
 
 
 @router.get("/api/forms/servers", response_model=SelectSearchResponse)


### PR DESCRIPTION
The version of samdb that runs in production does not have a `disconnect()` method.

For now, we will dereference the variable.